### PR TITLE
Copy a format string before passing bang methods

### DIFF
--- a/lib/era_ja/conversion.rb
+++ b/lib/era_ja/conversion.rb
@@ -15,7 +15,7 @@ module EraJa
     #   * %J - kanzi number
     # @return [String]
     def to_era(format = "%o%E.%m.%d")
-      @era_format = format
+      @era_format = format.dup
       @era_format.gsub!(/%J/, "%J%")
       @era_format.sub!(/%o/i) { |m| m + ' ' }
       @era_format.sub!(/%E/) { |m| m + ' ' }


### PR DESCRIPTION
because it potentially causes unexpected mutations for an actual argument.

e.g.

```
> format = '%O%E年'
> Time.now.to_era(format)
> format
=> "%O %E 年"
```