### PR TITLE
Fix usage document

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -56,8 +56,8 @@ Date.new(2012,4,29).to_era("%O%JE年%Jm月%Jd日") # => "平成二十四年四�
 
 
 ```ruby
-Time.mktime(2012,4,29).to_era("%Jy年%Jm月%Jd日") # => "二千十二年四月二十九日"
-Date.new(2012,4,29).to_era("%Jy年%Jm月%Jd日")    # => "二千十二年四月二十九日"
+Time.mktime(2012,4,29).to_era("%JY年%Jm月%Jd日") # => "二千十二年四月二十九日"
+Date.new(2012,4,29).to_era("%JY年%Jm月%Jd日")    # => "二千十二年四月二十九日"
 ```
 
 ### Era names ###

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ Date.new(2012,4,29).to_era("%O%JE年%Jm月%Jd日") # => "平成二十四年四�
 ### Convert numerals to kanzi ###
 
 ```ruby
-Time.mktime(2012,4,29).to_era("%Jy年%Jm月%Jd日") # => "二千十二年四月二十九日"
-Date.new(2012,4,29).to_era("%Jy年%Jm月%Jd日")    # => "二千十二年四月二十九日"
+Time.mktime(2012,4,29).to_era("%JY年%Jm月%Jd日") # => "二千十二年四月二十九日"
+Date.new(2012,4,29).to_era("%JY年%Jm月%Jd日")    # => "二千十二年四月二十九日"
 ```
 
 ### Era names ###

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -87,7 +87,7 @@ RSpec.shared_examples "should equal '2012年04月29日'" do
 end
 
 RSpec.shared_examples "should equal '二千十二年四月二十九日'" do
-  context "with '%Jy年%Jm月%Jd日'" do
+  context "with '%JY年%Jm月%Jd日'" do
     it { expect(subject.to_era('%JY年%Jm月%Jd日')).to eq '二千十二年四月二十九日' }
   end
 end


### PR DESCRIPTION
I read Usage and tried to do it on irb as follows.
```
irb(main):002:0> Time.mktime(2012,4,29).to_era("%Jy年%Jm月%Jd日")
=> "十二年四月二十九日"
irb(main):003:0> Date.new(2012,4,29).to_era("%Jy年%Jm月%Jd日")
=> "十二年四月二十九日"
```
But Usage document written as follows.
```
Time.mktime(2012,4,29).to_era("%Jy年%Jm月%Jd日") # => "二千十二年四月二十九日"
Date.new(2012,4,29).to_era("%Jy年%Jm月%Jd日")    # => "二千十二年四月二十九日"
```