### PR TITLE
Specify end of Heisei era

### DIFF
--- a/lib/era_ja/conversion.rb
+++ b/lib/era_ja/conversion.rb
@@ -10,7 +10,7 @@ module EraJa
       heisei: ["H", "平成"]
     }.freeze
 
-    ERR_DATE_OUT_OF_RANGE = "#to_era only works on dates after 1868,9,8".freeze
+    ERR_DATE_OUT_OF_RANGE = "#to_era only works on dates from 1868,9,8 to 2019,4,30".freeze
 
     # Convert to Japanese era.
     # @param [String] format_string
@@ -39,8 +39,10 @@ module EraJa
           str_time = era_year(year - 1911, :taisho, era_names)
         when self.to_time < ::Time.mktime(1989,1,8)
           str_time = era_year(year - 1925, :showa, era_names)
-        else
+        when self.to_time < ::Time.mktime(2019,5,1)
           str_time = era_year(year - 1988, :heisei, era_names)
+        else
+          raise ERR_DATE_OUT_OF_RANGE
         end
       end
       str_time.gsub(/%J(\d+)/) { to_kanzi($1) }

--- a/spec/date_spec.rb
+++ b/spec/date_spec.rb
@@ -5,6 +5,16 @@ require File.expand_path('spec_helper', File.dirname(__FILE__))
 RSpec.describe Date do
   describe "#to_era" do
 
+    context "date is 2019,5,1" do
+      subject { Date.new(2019,5,1) }
+      include_examples "2019,5,1"
+    end
+
+    context "date is 2019,4,30" do
+      subject { Date.new(2019,4,30) }
+      include_examples "2019,4,30"
+    end
+
     context "date is 2012,4,29" do
       subject { Date.new(2012,4,29) }
       include_examples "2012,4,29"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -74,6 +74,18 @@ RSpec.shared_examples "should equal '平240429'" do
   end
 end
 
+RSpec.shared_examples "should equal '平成31.04.30'" do
+  it { expect(subject.to_era("%O%E.%m.%d")).to eq "平成31.04.30" }
+end
+
+RSpec.shared_examples "should equal '平31.04.30'" do
+  it { expect(subject.to_era("%1O%E.%m.%d")).to eq "平31.04.30" }
+end
+
+RSpec.shared_examples "should equal 'H31.04.30'" do
+  it { expect(subject.to_era).to eq "H31.04.30" }
+end
+
 RSpec.shared_examples "should equal '平成二十四年四月二十九日'" do
   context "with '%O%JE年%Jm月%Jd日'" do
     it { expect(subject.to_era('%O%JE年%Jm月%Jd日')).to eq '平成二十四年四月二十九日' }
@@ -170,6 +182,20 @@ end
 
 RSpec.shared_examples "should raise error" do
   it { expect {subject.to_era}.to raise_error(RuntimeError, EraJa::Conversion::ERR_DATE_OUT_OF_RANGE) }
+end
+
+RSpec.shared_examples "2019,5,1" do
+  include_examples "should raise error"
+end
+
+# RSpec.shared_examples "2019,4,30" do
+#   include_examples "should equal 'H31.04.30'"
+# end
+
+RSpec.shared_examples "2019,4,30" do
+  include_examples "should equal 'H31.04.30'"
+  include_examples "should equal '平成31.04.30'"
+  include_examples "should equal '平31.04.30'"
 end
 
 RSpec.shared_examples "2012,4,29" do


### PR DESCRIPTION
A new era is scheduled, but its name has not yet been announced.

This commit:
* raises `RuntimeError` for dates >= 2019-05-01
* updates the tests