### PR TITLE
Fixed a bug that causes unintended `TypeError`

### DIFF
--- a/lib/era_ja/conversion.rb
+++ b/lib/era_ja/conversion.rb
@@ -73,7 +73,7 @@ module EraJa
     def to_kanzi(numeric, kanzi = "")
       figures = (10 ** numeric.to_s.size) / 10
       numeric = numeric.to_i
-      kanzi_string = [nil, "一", "二", "三", "四", "五", "六", "七", "八", "九"]
+      kanzi_string = ["", "一", "二", "三", "四", "五", "六", "七", "八", "九"]
       figures_string = { 1000 => "千", 100 => "百", 10 => "十", 1 => "" }
       return kanzi + kanzi_string[numeric] if figures == 1
 

--- a/spec/date_spec.rb
+++ b/spec/date_spec.rb
@@ -5,6 +5,11 @@ require File.expand_path('spec_helper', File.dirname(__FILE__))
 RSpec.describe Date do
   describe "#to_era" do
 
+    context 'date is 2019,4,30' do
+      subject { Date.new(2019,4,30) }
+      include_examples "2019,4,30"
+    end
+
     context "date is 2012,4,29" do
       subject { Date.new(2012,4,29) }
       include_examples "2012,4,29"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,66 @@
 # -*- coding: utf-8 -*-
 require 'rspec'
 
+RSpec.shared_examples "should equal 'H31.04.30'" do
+  context "with '%o%E.%m.%d'" do
+    it { expect(subject.to_era("%o%E.%m.%d")).to eq "H31.04.30" }
+  end
+end
+
+RSpec.shared_examples "should equal '平成31年04月30日'" do
+  context "with '%O%E年%m月%d日'" do
+    it { expect(subject.to_era("%O%E年%m月%d日")).to eq "平成31年04月30日" }
+  end
+end
+
+RSpec.shared_examples "should equal '平31年04月30日'" do
+  context "with '%1O%E年%m月%d日'" do
+    it { expect(subject.to_era("%1O%E年%m月%d日")).to eq "平31年04月30日" }
+  end
+end
+
+RSpec.shared_examples "should equal '31.04.30'" do
+  context "with '%E.%m.%d'" do
+    it { expect(subject.to_era("%E.%m.%d")).to eq "31.04.30" }
+  end
+end
+
+RSpec.shared_examples "should equal '3104'" do
+  context "with '%E%m'" do
+    it { expect(subject.to_era("%E%m")).to eq "3104" }
+  end
+end
+
+RSpec.shared_examples "should equal '平成310430'" do
+  context "with '%O%E%m%d'" do
+    it { expect(subject.to_era("%O%E%m%d")).to eq "平成310430" }
+  end
+end
+
+RSpec.shared_examples "should equal '平310430'" do
+  context "with '%1O%E%m%d'" do
+    it { expect(subject.to_era("%1O%E%m%d")).to eq "平310430" }
+  end
+end
+
+RSpec.shared_examples "should equal '2019年04月30日'" do
+  context "with '%Y年%m月%d日'" do
+    it { expect(subject.to_era("%Y年%m月%d日")).to eq "2019年04月30日" }
+  end
+end
+
+RSpec.shared_examples "should equal '平成三十一年四月三十日'" do
+  context "with '%O%JE年%Jm月%Jd日'" do
+    it { expect(subject.to_era("%O%JE年%Jm月%Jd日")).to eq "平成三十一年四月三十日" }
+  end
+end
+
+RSpec.shared_examples "should equal '二千十九年四月三十日'" do
+  context "with '%JY年%Jm月%Jd日'" do
+    it { expect(subject.to_era("%JY年%Jm月%Jd日")).to eq "二千十九年四月三十日" }
+  end
+end
+
 RSpec.shared_examples "should equal 'H24.04.29'" do
   it { expect(subject.to_era).to eq "H24.04.29" }
 
@@ -170,6 +230,19 @@ end
 
 RSpec.shared_examples "should raise error" do
   it { expect {subject.to_era}.to raise_error(RuntimeError, EraJa::Conversion::ERR_DATE_OUT_OF_RANGE) }
+end
+
+RSpec.shared_examples "2019,4,30" do
+  include_examples "should equal 'H31.04.30'"
+  include_examples "should equal '平成31年04月30日'"
+  include_examples "should equal '平31年04月30日'"
+  include_examples "should equal '31.04.30'"
+  include_examples "should equal '3104'"
+  include_examples "should equal '平成310430'"
+  include_examples "should equal '平310430'"
+  include_examples "should equal '2019年04月30日'"
+  include_examples "should equal '平成三十一年四月三十日'"
+  include_examples "should equal '二千十九年四月三十日'"
 end
 
 RSpec.shared_examples "2012,4,29" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,54 +1,6 @@
 # -*- coding: utf-8 -*-
 require 'rspec'
 
-RSpec.shared_examples "should equal 'H31.04.30'" do
-  context "with '%o%E.%m.%d'" do
-    it { expect(subject.to_era("%o%E.%m.%d")).to eq "H31.04.30" }
-  end
-end
-
-RSpec.shared_examples "should equal '平成31年04月30日'" do
-  context "with '%O%E年%m月%d日'" do
-    it { expect(subject.to_era("%O%E年%m月%d日")).to eq "平成31年04月30日" }
-  end
-end
-
-RSpec.shared_examples "should equal '平31年04月30日'" do
-  context "with '%1O%E年%m月%d日'" do
-    it { expect(subject.to_era("%1O%E年%m月%d日")).to eq "平31年04月30日" }
-  end
-end
-
-RSpec.shared_examples "should equal '31.04.30'" do
-  context "with '%E.%m.%d'" do
-    it { expect(subject.to_era("%E.%m.%d")).to eq "31.04.30" }
-  end
-end
-
-RSpec.shared_examples "should equal '3104'" do
-  context "with '%E%m'" do
-    it { expect(subject.to_era("%E%m")).to eq "3104" }
-  end
-end
-
-RSpec.shared_examples "should equal '平成310430'" do
-  context "with '%O%E%m%d'" do
-    it { expect(subject.to_era("%O%E%m%d")).to eq "平成310430" }
-  end
-end
-
-RSpec.shared_examples "should equal '平310430'" do
-  context "with '%1O%E%m%d'" do
-    it { expect(subject.to_era("%1O%E%m%d")).to eq "平310430" }
-  end
-end
-
-RSpec.shared_examples "should equal '2019年04月30日'" do
-  context "with '%Y年%m月%d日'" do
-    it { expect(subject.to_era("%Y年%m月%d日")).to eq "2019年04月30日" }
-  end
-end
-
 RSpec.shared_examples "should equal '平成三十一年四月三十日'" do
   context "with '%O%JE年%Jm月%Jd日'" do
     it { expect(subject.to_era("%O%JE年%Jm月%Jd日")).to eq "平成三十一年四月三十日" }
@@ -233,14 +185,6 @@ RSpec.shared_examples "should raise error" do
 end
 
 RSpec.shared_examples "2019,4,30" do
-  include_examples "should equal 'H31.04.30'"
-  include_examples "should equal '平成31年04月30日'"
-  include_examples "should equal '平31年04月30日'"
-  include_examples "should equal '31.04.30'"
-  include_examples "should equal '3104'"
-  include_examples "should equal '平成310430'"
-  include_examples "should equal '平310430'"
-  include_examples "should equal '2019年04月30日'"
   include_examples "should equal '平成三十一年四月三十日'"
   include_examples "should equal '二千十九年四月三十日'"
 end

--- a/spec/time_spec.rb
+++ b/spec/time_spec.rb
@@ -5,6 +5,11 @@ require File.expand_path('spec_helper', File.dirname(__FILE__))
 RSpec.describe Time do
   describe "#to_era" do
 
+    context 'time is 2019,4,30' do
+      subject { Date.new(2019,4,30) }
+      include_examples "2019,4,30"
+    end
+
     context "time is 2012,4,29" do
       subject { Time.mktime(2012,4,29) }
       include_examples "2012,4,29"


### PR DESCRIPTION
Thank you for creating a nice gem !
I found a bug in this gem and fixed it.
Note that this bug has already been fixed, so please check the code in detail. and review.

# Details
Fixed a bug that caused Type Error when the argument `numeric` of` to_kanji` is a multiple of 10

```
$ bundle exec rspec spec
........FF.........................................FF.................................

Failures:

  1) Date#to_era date is 2019,4,30 with '%O%JE年%Jm月%Jd日'
     Failure/Error: it { expect(subject.to_era("%O%JE年%Jm月%Jd日")).to eq "平成三十一年四月三十日" }
     TypeError:
       no implicit conversion of nil into String
     # ./lib/era_ja/conversion.rb:78:in `+'
     # ./lib/era_ja/conversion.rb:78:in `to_kanzi'
     # ./lib/era_ja/conversion.rb:82:in `to_kanzi'
     # ./lib/era_ja/conversion.rb:46:in `block in to_era'
     # ./lib/era_ja/conversion.rb:46:in `gsub'
     # ./lib/era_ja/conversion.rb:46:in `to_era'
     # ./spec/spec_helper.rb:54:in `block (3 levels) in <top (required)>'

  2) Date#to_era date is 2019,4,30 with '%JY年%Jm月%Jd日'
     Failure/Error: it { expect(subject.to_era("%JY年%Jm月%Jd日")).to eq "二千十九年四月三十日" }
     TypeError:
       no implicit conversion of nil into String
     # ./lib/era_ja/conversion.rb:78:in `+'
     # ./lib/era_ja/conversion.rb:78:in `to_kanzi'
     # ./lib/era_ja/conversion.rb:82:in `to_kanzi'
     # ./lib/era_ja/conversion.rb:46:in `block in to_era'
     # ./lib/era_ja/conversion.rb:46:in `gsub'
     # ./lib/era_ja/conversion.rb:46:in `to_era'
     # ./spec/spec_helper.rb:60:in `block (3 levels) in <top (required)>'

  3) Time#to_era time is 2019,4,30 with '%O%JE年%Jm月%Jd日'
     Failure/Error: it { expect(subject.to_era("%O%JE年%Jm月%Jd日")).to eq "平成三十一年四月三十日" }
     TypeError:
       no implicit conversion of nil into String
     # ./lib/era_ja/conversion.rb:78:in `+'
     # ./lib/era_ja/conversion.rb:78:in `to_kanzi'
     # ./lib/era_ja/conversion.rb:82:in `to_kanzi'
     # ./lib/era_ja/conversion.rb:46:in `block in to_era'
     # ./lib/era_ja/conversion.rb:46:in `gsub'
     # ./lib/era_ja/conversion.rb:46:in `to_era'
     # ./spec/spec_helper.rb:54:in `block (3 levels) in <top (required)>'

  4) Time#to_era time is 2019,4,30 with '%JY年%Jm月%Jd日'
     Failure/Error: it { expect(subject.to_era("%JY年%Jm月%Jd日")).to eq "二千十九年四月三十日" }
     TypeError:
       no implicit conversion of nil into String
     # ./lib/era_ja/conversion.rb:78:in `+'
     # ./lib/era_ja/conversion.rb:78:in `to_kanzi'
     # ./lib/era_ja/conversion.rb:82:in `to_kanzi'
     # ./lib/era_ja/conversion.rb:46:in `block in to_era'
     # ./lib/era_ja/conversion.rb:46:in `gsub'
     # ./lib/era_ja/conversion.rb:46:in `to_era'
     # ./spec/spec_helper.rb:60:in `block (3 levels) in <top (required)>'

Finished in 0.06435 seconds (files took 1.44 seconds to load)
86 examples, 4 failures

Failed examples:

rspec ./spec/spec_helper.rb:54 # Date#to_era date is 2019,4,30 with '%O%JE年%Jm月%Jd日'
rspec ./spec/spec_helper.rb:60 # Date#to_era date is 2019,4,30 with '%JY年%Jm月%Jd日'
rspec ./spec/spec_helper.rb:54 # Time#to_era time is 2019,4,30 with '%O%JE年%Jm月%Jd日'
rspec ./spec/spec_helper.rb:60 # Time#to_era time is 2019,4,30 with '%JY年%Jm月%Jd日'
```