### PR TITLE
Raise a custom error rather than RuntimeError

### DIFF
--- a/lib/era_ja.rb
+++ b/lib/era_ja.rb
@@ -2,3 +2,4 @@
 require "era_ja/version"
 require "era_ja/date"
 require "era_ja/time"
+require "era_ja/error"

--- a/lib/era_ja/conversion.rb
+++ b/lib/era_ja/conversion.rb
@@ -11,8 +11,6 @@ module EraJa
       reiwa:  ["R", "令和"]
     }.freeze
 
-    ERR_DATE_OUT_OF_RANGE = "#to_era only works on dates after 1868,9,8".freeze
-
     # Convert to Japanese era.
     # @param [String] format_string
     #   Time#strftime format string can be used
@@ -33,7 +31,7 @@ module EraJa
       if @era_format =~ /%([EOo]|1O)/
         case
         when self.to_time < ::Time.mktime(1868,9,8)
-          raise ERR_DATE_OUT_OF_RANGE
+          raise EraJa::DateOutOfRangeError
         when self.to_time < ::Time.mktime(1912,7,30)
           str_time = era_year(year - 1867, :meiji, era_names)
         when self.to_time < ::Time.mktime(1926,12,25)

--- a/lib/era_ja/error.rb
+++ b/lib/era_ja/error.rb
@@ -1,0 +1,9 @@
+module EraJa
+  class DateOutOfRangeError < StandardError
+    ERR_DATE_OUT_OF_RANGE = "#to_era only works on dates after 1868,9,8".freeze
+
+    def message
+      ERR_DATE_OUT_OF_RANGE
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 require 'rspec'
+require File.expand_path('../lib/era_ja/error', File.dirname(__FILE__))
 
 RSpec.shared_examples "should equal 'R01.07.02'" do
   it { expect(subject.to_era).to eq "R01.07.02" }
@@ -311,7 +312,7 @@ RSpec.shared_examples "should equal 'M01.09.08'" do
 end
 
 RSpec.shared_examples "should raise error" do
-  it { expect {subject.to_era}.to raise_error(RuntimeError, EraJa::Conversion::ERR_DATE_OUT_OF_RANGE) }
+  it { expect {subject.to_era}.to raise_error(EraJa::DateOutOfRangeError, EraJa::DateOutOfRangeError::ERR_DATE_OUT_OF_RANGE) }
 end
 
 RSpec.shared_examples "2020,1,1" do


### PR DESCRIPTION
Hi!

When the receiver date of `to_era` method was before September 8, 1868, RuntimeError was raised.

```ruby
require 'era_ja'

date = Date.new(1868, 9, 7)

begin
  date.to_era
rescue => e
  puts e.class
  #=> RuntimeError
end
```

But I think it's better that a more specific error raised rather than RuntimeError.
Therefore, this PR defines a custom error ( `EraJa::Conversion::DateOutOfRangeError` ), makes `to_era` raise that.