### PR TITLE
Add a method to check if a date is convertible or not

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -79,6 +79,18 @@ Time.mktime(2012,4,29).to_era("%O%JE年%Jm月%Jd日", era_names: { heisei: ['h',
 # same as Date
 ```
 
+### 元号に変換できるかどうかの判定方法 ###
+
+日付が元号に変換できるかどうかを判定するために、`era_convertible?` を使うことができます。 
+
+```ruby
+require 'era_ja'
+Time.mktime(1868,9,7).era_convertible? #=> false
+Time.mktime(1868,9,8).era_convertible? #=> true
+```
+
+元号に変換できない日付に関しては、Noteセクションを参照してください。
+
 ## Support
 
 問題を報告したり、機能追加の要望する場合はgithubのIssuesに登録してください。 https://github.com/tomiacannondale/era_ja/issues

--- a/README.md
+++ b/README.md
@@ -80,6 +80,18 @@ Time.mktime(2012,4,29).to_era("%O%JE年%Jm月%Jd日", era_names: { heisei: ['h',
 # same as Date
 ```
 
+### Checking a date is convertible ###
+
+You can use `era_convertible?` to check if a given date is convertible or not. 
+
+```ruby
+require 'era_ja'
+Time.mktime(1868,9,7).era_convertible? #=> false
+Time.mktime(1868,9,8).era_convertible? #=> true
+```
+
+See Note section for more details.
+
 ## Support
 
 Report issues and feature requests to github Issues. https://github.com/tomiacannondale/era_ja/issues

--- a/lib/era_ja/conversion.rb
+++ b/lib/era_ja/conversion.rb
@@ -28,12 +28,12 @@ module EraJa
     #    this argument is same as one element of ERA_NAME_DEFAULTS.
     # @return [String]
     def to_era(format = "%o%E.%m.%d", era_names: ERA_NAME_DEFAULTS)
+      raise ERR_DATE_OUT_OF_RANGE unless era_convertible?
+      
       @era_format = format.gsub(/%J/, "%J%")
       str_time = strftime(@era_format)
       if @era_format =~ /%([EOo]|1O)/
         case
-        when !era_convertible?
-          raise ERR_DATE_OUT_OF_RANGE
         when self.to_time < ::Time.mktime(1912,7,30)
           str_time = era_year(year - 1867, :meiji, era_names)
         when self.to_time < ::Time.mktime(1926,12,25)

--- a/lib/era_ja/conversion.rb
+++ b/lib/era_ja/conversion.rb
@@ -32,7 +32,7 @@ module EraJa
       str_time = strftime(@era_format)
       if @era_format =~ /%([EOo]|1O)/
         case
-        when self.to_time < ::Time.mktime(1868,9,8)
+        when !era_convertible?
           raise ERR_DATE_OUT_OF_RANGE
         when self.to_time < ::Time.mktime(1912,7,30)
           str_time = era_year(year - 1867, :meiji, era_names)
@@ -47,6 +47,10 @@ module EraJa
         end
       end
       str_time.gsub(/%J(\d+)/) { to_kanzi($1) }
+    end
+
+    def era_convertible?
+      self.to_time >= ::Time.mktime(1868,9,8)
     end
 
     private

--- a/spec/date_spec.rb
+++ b/spec/date_spec.rb
@@ -73,4 +73,20 @@ RSpec.describe Date do
 
   end
 
+  describe "#era_convertible?" do
+
+    context "when date is not convertible" do
+      it "returns false" do
+        expect(Date.new(1868,9,7).era_convertible?).to be false
+      end
+    end
+
+    context "when date is convertible" do
+      it "returns true" do
+        expect(Date.new(1868,9,8).era_convertible?).to be true
+      end
+    end
+
+  end
+
 end


### PR DESCRIPTION
## Description

This PR proposes a method to check if a given date is convertible to era or not. Users can handle unsupported old dates by calling this method without raising an exception. This will be a simple way rather than capturing an exception raised by `to_era` method.

## Example

```ruby
require 'era_ja'

Time.mktime(1868,9,7).era_convertible? #=> false
Time.mktime(1868,9,8).era_convertible? #=> true
```

## Notes

This PR is aimed to solve a same issue with #18.  Applying both changes would be better and cause no problems.
