### PR TITLE
Fix conversion '%-E' without era name format to single digit era year

### DIFF
--- a/lib/era_ja/conversion.rb
+++ b/lib/era_ja/conversion.rb
@@ -30,7 +30,7 @@ module EraJa
 
       @era_format = format.gsub(/%J/, "%J%")
       str_time = strftime(@era_format)
-      if @era_format =~ /%([EOo]|1O)/
+      if @era_format =~ /%(-?E|[Oo]|1O)/
         case
         when self.to_time < ::Time.mktime(1912,7,30)
           str_time = era_year(year - 1867, :meiji, era_names)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,10 @@ RSpec.shared_examples "should equal '令和01年07月02日'" do
   context "with '%O%J%-E年%m月%d日'" do
     it { expect(subject.to_era("%O%J%-E年%m月%d日")).to eq "令和元年07月02日" }
   end
+
+  context "with '%-E年%-m月%-d日'" do
+    it { expect(subject.to_era("%-E年%-m月%-d日")).to eq "1年7月2日" }
+  end
 end
 
 RSpec.shared_examples "should equal 'R01.05.01'" do


### PR DESCRIPTION
I found `'%-E'` without era name format (e.g. `'%O'`) formats nothing.
For example `Time.zone.now.to_era('%-E')` results `'%-E'`.

So I fixed to detect `'%-E'` in `era_format` to generate `era_year`.